### PR TITLE
fix gorm text type not being used

### DIFF
--- a/create.go
+++ b/create.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm/clause"
 	gormSchema "gorm.io/gorm/schema"
 
-	"github.com/cengsin/oracle/clauses"
+	"github.com/NicuDine/oracle/clauses"
 )
 
 func Create(db *gorm.DB) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/NicuDine/oracle
 go 1.14
 
 require (
-	github.com/cengsin/oracle v1.0.0
 	github.com/emirpasic/gods v1.12.0
 	github.com/godror/godror v0.20.0
 	github.com/thoas/go-funk v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/cengsin/oracle
+module github.com/NicuDine/oracle
 
 go 1.14
 
 require (
+	github.com/cengsin/oracle v1.0.0
 	github.com/emirpasic/gods v1.12.0
 	github.com/godror/godror v0.20.0
 	github.com/thoas/go-funk v0.7.0

--- a/oracle.go
+++ b/oracle.go
@@ -198,7 +198,7 @@ func (d Dialector) DataTypeOf(field *schema.Field) string {
 	case schema.Bytes:
 		sqlType = "BLOB"
 	default:
-		sqlType := string(field.DataType)
+		sqlType = string(field.DataType)
 
 		if strings.EqualFold(sqlType, "text") {
 			sqlType = "CLOB"


### PR DESCRIPTION
If one describes a string field as `gorm:"type:text". It will not be taken into consideration as the sql variable defined in default is different than the original one at line 155. `:=` creating a new variable. As the function returns the first variable in this case it will actually return an empty string.