### PR TITLE
fix gorm text type not applying

### DIFF
--- a/oracle.go
+++ b/oracle.go
@@ -198,7 +198,7 @@ func (d Dialector) DataTypeOf(field *schema.Field) string {
 	case schema.Bytes:
 		sqlType = "BLOB"
 	default:
-		sqlType := string(field.DataType)
+		sqlType = string(field.DataType)
 
 		if strings.EqualFold(sqlType, "text") {
 			sqlType = "CLOB"


### PR DESCRIPTION
If one describes a string field as gorm:"type:text". It will not be taken into consideration as the sql variable defined in default is different than the original one at line 155. :=` creating a new variable. As the function returns the first variable in this case it will actually return an empty string.