### PR TITLE
Changes to support newer versions of godror/gorm.

### DIFF
--- a/create.go
+++ b/create.go
@@ -134,7 +134,7 @@ func Create(db *gorm.DB) {
 							func(field *gormSchema.Field) {
 								switch insertTo.Kind() {
 								case reflect.Struct:
-									if err = field.Set(insertTo, stmt.Vars[boundVars[field.Name]].(sql.Out).Dest); err != nil {
+									if err = field.Set(stmt.Context, insertTo, stmt.Vars[boundVars[field.Name]].(sql.Out).Dest); err != nil {
 										db.AddError(err)
 									}
 								case reflect.Map:

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/cengsin/oracle
 go 1.14
 
 require (
-	github.com/emirpasic/gods v1.12.0
-	github.com/godror/godror v0.20.0
-	github.com/thoas/go-funk v0.7.0
-	gorm.io/gorm v1.20.1
+	github.com/emirpasic/gods v1.18.1
+	github.com/godror/godror v0.34.0
+	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/thoas/go-funk v0.9.2
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+	gorm.io/gorm v1.24.0
 )

--- a/oracle.go
+++ b/oracle.go
@@ -50,7 +50,7 @@ func (d Dialector) Initialize(db *gorm.DB) (err error) {
 	d.DefaultStringSize = 1024
 
 	// register callbacks
-	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{WithReturning: true})
+	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{})
 
 	d.DriverName = "godror"
 
@@ -98,7 +98,7 @@ func (d Dialector) RewriteLimit(c clause.Clause, builder clause.Builder) {
 			builder.WriteString(strconv.Itoa(offset))
 			builder.WriteString(" ROWS")
 		}
-		if limit := limit.Limit; limit > 0 {
+		if limit := *(limit.Limit); limit > 0 {
 			builder.WriteString(" FETCH NEXT ")
 			builder.WriteString(strconv.Itoa(limit))
 			builder.WriteString(" ROWS ONLY")


### PR DESCRIPTION
Changes to support newer versions of godror/gorm. 

Newest packages give these errors:

go/pkg/mod/github.com/cengsin/oracle@v1.0.0/create.go:137:39: not enough arguments in call to field.Set
        have (reflect.Value, any)
        want (context.Context, reflect.Value, interface{})
go/pkg/mod/github.com/cengsin/oracle@v1.0.0/oracle.go:53:59: unknown field 'WithReturning' in struct literal of type callbacks.Config
go/pkg/mod/github.com/cengsin/oracle@v1.0.0/oracle.go:101:36: cannot convert 0 (untyped int constant) to *int
go/pkg/mod/github.com/cengsin/oracle@v1.0.0/oracle.go:103:37: cannot use limit (variable of type *int) as type int in argument to strconv.Itoa
